### PR TITLE
robust-ed install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+FiraCode.zip
+Meslo.zip

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ A default configuration for a minimal desktop after fresh server installation, b
 
 install essential components for desktop
 
-# Usage:
+## Usage:
 
     ./install.sh [OPTION] 
     ./install.sh [all|essential|optional] 
 
-# Options:
+## Options:
 
 - -h - display this help message and exit
 - -v - turn on debug mode (verbose) 
 - -V - display version 
 
-# Meta Options (overrides Switches)
+## Meta Options (overrides Switches)
 
 - all - install all components, with configs 
 - essential - install essential components (sddm, bspwm, sxhkd, kitty, rofi, 
@@ -26,7 +26,7 @@ install essential components for desktop
 - optional - install optional components (mangohud, gimp, vim, lxappearance) 
             with configs 
 
-# Switches (more granular control) 
+## Switches (more granular control) 
 
 - -a  -  install lxappearance 
 - -b  -  install background (in bg.jpg) 
@@ -49,7 +49,7 @@ install essential components for desktop
 - -x  -  install sxhkd hotkey manager 
 - -X  -  install Xorg option files
 
-# Examples:
+## Examples:
 
     ./install all          (installs all components) 
     ./install essential    (installs all essential components) 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ install essential components for desktop
 
 # Examples:
 
-    $(basename $0) all          (installs all components) 
-    $(basename $0) essential    (installs all essential components) 
-    $(basename $0) -wc          (installs bspwm and copies configs) 
+    ./install all          (installs all components) 
+    ./install essential    (installs all essential components) 
+    ./install -wc          (installs bspwm and copies configs) 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # Fedora-Titus
+
+A default configuration for a minimal desktop after fresh server installation, based on Fedora Server.
+
+# install.sh
+
+install essential components for desktop
+
+# Usage:
+
+    ./install.sh [OPTION] 
+    ./install.sh [all|essential|optional] 
+
+# Options:
+
+- -h    display this help message and exit
+- -v    turn on debug mode (verbose) 
+- -V    display version 
+
+# Meta Options (overrides Switches)
+
+-  all       install all components, with configs 
+-  essential install essential components (sddm, bspwm, sxhkd, kitty, rofi, 
+            polybar, picom, thunar, nitrogen, lxpolkit, ocs-url, fonts, Xcfgs)
+            with configs 
+-  optional  install optional components (mangohud, gimp, vim, lxappearance) 
+            with configs 
+
+# Switches (more granular control) 
+
+- -a    install lxappearance 
+- -b    install background (in bg.jpg) 
+- -c    copy configs of selected components into ~/.config 
+- -f    install fonts
+- -g    install GIMP
+- -k    install kitty terminal emulator 
+- -l    install lxpolkit 
+- -m    install mangohud 
+- -M    install vim 
+- -n    install nitrogen background picker 
+- -o    install ocs-url package 
+- -p    install polybar panel 
+- -P    install picom compositor 
+- -r    install rofi menu 
+- -s    install sddm display manager 
+- -t    install thunar file browser 
+- -u    run system update 
+- -w    install bspwm window manager 
+- -x    install sxhkd hotkey manager 
+- -X    install Xorg option files
+
+# Examples:
+
+    $(basename $0) all          (installs all components) 
+    $(basename $0) essential    (installs all essential components) 
+    $(basename $0) -wc          (installs bspwm and copies configs) 

--- a/README.md
+++ b/README.md
@@ -13,41 +13,41 @@ install essential components for desktop
 
 # Options:
 
-- -h    display this help message and exit
-- -v    turn on debug mode (verbose) 
-- -V    display version 
+- -h - display this help message and exit
+- -v - turn on debug mode (verbose) 
+- -V - display version 
 
 # Meta Options (overrides Switches)
 
--  all       install all components, with configs 
--  essential install essential components (sddm, bspwm, sxhkd, kitty, rofi, 
+- all - install all components, with configs 
+- essential - install essential components (sddm, bspwm, sxhkd, kitty, rofi, 
             polybar, picom, thunar, nitrogen, lxpolkit, ocs-url, fonts, Xcfgs)
             with configs 
--  optional  install optional components (mangohud, gimp, vim, lxappearance) 
+- optional - install optional components (mangohud, gimp, vim, lxappearance) 
             with configs 
 
 # Switches (more granular control) 
 
-- -a    install lxappearance 
-- -b    install background (in bg.jpg) 
-- -c    copy configs of selected components into ~/.config 
-- -f    install fonts
-- -g    install GIMP
-- -k    install kitty terminal emulator 
-- -l    install lxpolkit 
-- -m    install mangohud 
-- -M    install vim 
-- -n    install nitrogen background picker 
-- -o    install ocs-url package 
-- -p    install polybar panel 
-- -P    install picom compositor 
-- -r    install rofi menu 
-- -s    install sddm display manager 
-- -t    install thunar file browser 
-- -u    run system update 
-- -w    install bspwm window manager 
-- -x    install sxhkd hotkey manager 
-- -X    install Xorg option files
+- -a  -  install lxappearance 
+- -b  -  install background (in bg.jpg) 
+- -c  -  copy configs of selected components into ~/.config 
+- -f  -  install fonts
+- -g  -  install GIMP
+- -k  -  install kitty terminal emulator 
+- -l  -  install lxpolkit 
+- -m  -  install mangohud 
+- -M  -  install vim 
+- -n  -  install nitrogen background picker 
+- -o  -  install ocs-url package 
+- -p  -  install polybar panel 
+- -P  -  install picom compositor 
+- -r  -  install rofi menu 
+- -s  -  install sddm display manager 
+- -t  -  install thunar file browser 
+- -u  -  run system update 
+- -w  -  install bspwm window manager 
+- -x  -  install sxhkd hotkey manager 
+- -X  -  install Xorg option files
 
 # Examples:
 

--- a/dotconfig/polybar/config
+++ b/dotconfig/polybar/config
@@ -295,17 +295,17 @@ format-background = ${colors.shade16}
 format-overline = ${colors.background}
 format-underline = ${colors.background}
 
-[module/vpn]
-type = custom/ipc
-initial = 2
-format-foreground = ${colors.shade5}
-format-background = ${colors.shade16}
-format-overline = ${colors.background}
+;[module/vpn]
+;type = custom/ipc
+;initial = 2
+;format-foreground = ${colors.shade5}
+;format-background = ${colors.shade16}
+;format-overline = ${colors.background}
 
-format-underline = ${colors.background}
+;format-underline = ${colors.background}
 
-hook-0 = echo "%{A1:sudo pkill openconnect && polybar-msg hook vpn 2:}%{F#a3be8c} %{F-}%{A}" &
-hook-1 = echo "%{A1:pass sshthanos | sudo openconnect vpn.som.umaryland.edu -b -q --user=cullen.ross --authgroup SOM-Multifactor --passwd-on-stdin --servercert pin-sha256\:zWuWUmGaQEWraG+Xvv6uF58rrupSRmqCzeNioSDEaaI= && polybar-msg hook vpn 1:}%{F#3b4252} %{F-}%{A}" &
+;hook-0 = echo "%{A1:sudo pkill openconnect && polybar-msg hook vpn 2:}%{F#a3be8c} %{F-}%{A}" &
+;hook-1 = echo "%{A1:pass sshthanos | sudo openconnect vpn.som.umaryland.edu -b -q --user=cullen.ross --authgroup SOM-Multifactor --passwd-on-stdin --servercert pin-sha256\:zWuWUmGaQEWraG+Xvv6uF58rrupSRmqCzeNioSDEaaI= && polybar-msg hook vpn 1:}%{F#3b4252} %{F-}%{A}" &
 
 [module/dunst]
 type = custom/ipc

--- a/install.sh
+++ b/install.sh
@@ -295,10 +295,10 @@ main () {
   if [[ ${FONTS} ]]; then
     debug "downloading nerd fonts..."
     if [[ ! -f Meslo.zip ]]; then
-      debug "$(wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip 2>&1)"
+      debug "$(wget -q https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip 2>&1)"
     fi
     if [[ ! -f FiraCode.zip ]]; then
-      debug "$(wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip 2>&1)"
+      debug "$(wget -q https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip 2>&1)"
     fi
     debug "unzipping nerd fonts..."
     if [[ ! -d ~/.fonts ]]; then

--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,7 @@ parse_args () {
     fi
 
     if [[ ! ${ARGS[0]} && ${NUM_OPTS} -eq 0 ]]; then
+      debug "no actionable options, setting to all"
       ARGS[0]="all"
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -272,8 +272,8 @@ main () {
 
   if [[ ${INSTALL_LIST} ]]; then
     debug "installing packages..."
-    if [[ ! $(which wget) ]]; then INSTALL_LIST+=("wget"); fi
-    if [[ ! $(which unzip) ]]; then INSTALL_LIST+=("unzip"); fi
+    if [[ ! $(which wget 2>&1>/dev/null) ]]; then INSTALL_LIST+=("wget"); fi
+    if [[ ! $(which unzip 2>&1>/dev/null) ]]; then INSTALL_LIST+=("unzip"); fi
     debug "$(sudo dnf -y install ${INSTALL_LIST[@]} 2>&1)"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -176,7 +176,7 @@ parse_args () {
         for config in $(ls dotconfig); do
           configcmp=$(echo $config | cut -d . -f1)
           if [[ " ${pkg^^} " =~ " ${configcmp^^} " ]]; then
-            CONFIG_LIST+=("./dotconfig/${config}")
+            CONFIG_LIST+=("${config}")
           fi
         done
       done

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,8 @@ parse_args () {
       CONFIGS=y
       FONTS=y
       BG=y
+    elif [[ ${ARGS[0]} != "" || ${NUM_OPTS} -lt 1 ]]; then
+      finish ${ERR_NOTENUF_OPT} "no valid options given"
     fi
 
     if [[ "${CONFIGS}" == "y" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,230 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Check if Script is Run as Root
-if [[ $EUID -ne 0 ]]; then
-  echo "You must be a root user to run this script, please run sudo ./install.sh" 2>&1
-  exit 1
-fi
+readonly VERSION="1.0.0"
+readonly ERR_UNK_OPT=64
+readonly ERR_TOOMANY_OPT=65
+readonly ANSI_RED="\033[1;31m"
+readonly ANSI_CLEAR="\033[0m"
+readonly ANSI_YELLOW="\033[1;93m"
 
-# Updating System
-dnf update -y
+unset BG
+unset CONFIGS
+unset CONFIG_LIST
+unset DEBUG
+unset FONTS
+unset INSTALL_LIST
+unset UPDATE
+unset XCONFIGS
 
-# Making .config and Moving dotfiles and Background to .config
-mkdir ~/.config
-chown $(whoami): ~/.config
-mv ./dotconfig/* ~/.config
-mv ./bg.jpg ~/.config
+ARGS=()
+INSTALL_LIST=()
+CONFIG_LIST=()
 
-# Installing Essential Programs 
-dnf install sddm bspwm sxhkd kitty rofi polybar picom thunar nitrogen lxpolkit
-# Installing Other less important Programs
-dnf install mangohud gimp vim lxappearance
-# Installing Custom ocs-url package
-dnf install ./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm
+finish () {
+  local rc="$1"
+  local msg="$2"
+  if [[ $rc -gt 0 ]]; then
+    printf "${ANSI_RED}%s: %s${ANSI_CLEAR}\n" "$(basename $0)" "${msg}"
+    printf "Try: %s -h\n" "$(basename $0)"
+  fi
+  exit ${rc}
+} >&2
 
-# Installing fonts
-dnf install fontawesome-fonts fontawesome-fonts-web
-wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip
-unzip FiraCode.zip -d /usr/share/fonts
-wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip
-unzip Meslo.zip -d /usr/share/fonts
-# Reloading Font
-fc-cache -vf
-# Removing zip Files
-rm ./FiraCode.zip ./Meslo.zip
+usage () {
+  printf "\n\
+$(basename $0) - install essential components for desktop \n\
+\n\
+Usage: $(basename $0) [OPTION] \n\
+       $(basename $0) [all|essential|optional] \n\
+\n\
+Options: \n\
+  -h    display this help message and exit\n\
+  -v    turn on debug mode (verbose) \n\
+  -V    display version \n\
+\n\
+ Meta Options (overrides Switches) \n\
+  all       install all components, with configs \n\
+  essential install essential components (sddm, bspwm, sxhkd, kitty, rofi, \n\
+            polybar, picom, thunar, nitrogen, lxpolkit, ocs-url, fonts, Xcfgs)\n\
+            with configs \n\
+  optional  install optional components (mangohud, gimp, vim, lxappearance) \n\
+            with configs \n\
+\n\
+ Switches (more granular control) \n\
+  -a    install lxappearance \n\
+  -b    install background (in bg.jpg) \n\
+  -c    copy configs of selected components into ~/.config \n\
+  -f    install fonts
+  -g    install GIMP
+  -k    install kitty terminal emulator \n\
+  -l    install lxpolkit \n\
+  -m    install mangohud \n\
+  -M    install vim \n\
+  -n    install nitrogen background picker \n\
+  -o    install ocs-url package \n\
+  -p    install polybar panel \n\
+  -P    install picom compositor \n\
+  -r    install rofi menu \n\
+  -s    install sddm display manager \n\
+  -t    install thunar file browser \n\
+  -u    run system update \n\
+  -w    install bspwm window manager \n\
+  -x    install sxhkd hotkey manager \n\
+  -X    install Xorg option files
+\n\
+Examples: $(basename $0) all          (installs all components) \n\
+          $(basename $0) essential    (installs all essential components) \n\
+          $(basename $0) -wc          (installs bspwm and copies configs) \n\
+\n"
+}
 
-# Enabling Services and Graphical User Interface
-systemctl enable sddm
-systemctl set-default graphical.target
+debug () {
+  local msg="$1"
+  if [[ ${DEBUG} ]]; then
+    printf "${ANSI_YELLOW}[-]${ANSI_CLEAR} %s\n" "${msg}" >&2
+  fi
+}
+
+version () {
+  printf "${VERSION}\n"
+}
+
+parse_args () {
+    optstring=":hvVabcfklmMnopPrstuwxX"
+
+    while [[ $OPTIND -le "$#" ]]; do
+        if getopts ${optstring} arg; then
+            case ${arg} in
+                h) usage; finish 0 "" ;;
+                v) DEBUG=yes ;;
+                V) version; finish 0 "" ;;
+                a) INSTALL_LIST+=("lxappearance");;
+                b) BG=y;;
+                c) CONFIGS=y;;
+                f) FONTS=y;;
+                g) INSTALL_LIST+=("gimp");;
+                k) INSTALL_LIST+=("kitty");;
+                l) INSTALL_LIST+=("lxpolkit");;
+                m) INSTALL_LIST+=("mangohud");;
+                M) INSTALL_LIST+=("vim");;
+                n) INSTALL_LIST+=("nitrogen");;
+                o) INSTALL_LIST+=("./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm");;
+                p) INSTALL_LIST+=("polybar");;
+                P) INSTALL_LIST+=("picom");;
+                r) INSTALL_LIST+=("rofi");;
+                s) INSTALL_LIST+=("sddm");;
+                t) INSTALL_LIST+=("thunar");;
+                u) UPDATE=y;;
+                w) INSTALL_LIST+=("bspwm");;
+                x) INSTALL_LIST+=("sxhkd");;
+                X) XCONFIGS=y;;
+                ?) finish "${ERR_UNK_OPT}" "unkown option: -${OPTARG}";;
+            esac
+        else
+            ARGS+=("${!OPTIND}")
+            ((OPTIND++))
+        fi
+    done
+
+    if [[ ${#ARGS[@]} -gt 1  ]]; then
+      finish "${ERR_TOOMANY_OPT}" "too many options"
+    fi
+
+    if [[ ${ARGS[0]} == "all" ]]; then
+      debug "all selected, overriding switches"
+      INSTALL_LIST=("sxhkd" "bspwm" "thunar" "sddm" "rofi" "picom" \
+        "polybar" "./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm" \
+        "nitrogen" "vim" "mangohud" "lxpolkit" "kitty" "lxappearance" \
+        "gimp")
+      XCONFIGS=y
+      UPDATE=y
+      CONFIGS=y
+      FONTS=y
+      BG=y
+    fi
+
+    if [[ ${ARGS[0]} == "essential" ]]; then
+      debug "essential selected, overriding switches"
+      INSTALL_LIST=("sxhkd" "bspwm" "thunar" "sddm" "rofi" "picom" \
+        "polybar" "./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm" \
+        "nitrogen" "lxpolkit" "kitty")
+      XCONFIGS=y
+      UPDATE=y
+      CONFIGS=y
+      FONTS=y
+      BG=y
+    fi
+
+    if [[ ${ARGS[0]} == "optional" ]]; then
+      debug "optional selected, overriding switches"
+      INSTALL_LIST=("vim" "mangohud" "lxappearance" "gimp")
+      XCONFIGS=y
+      UPDATE=y
+      CONFIGS=y
+      FONTS=y
+      BG=y
+    fi
+
+    if [[ "${CONFIGS}" == "y" ]]; then
+      for pkg in ${INSTALL_LIST[@]}; do
+        for config in $(ls dotconfig); do
+          configcmp=$(echo $config | cut -d . -f1)
+          if [[ " ${pkg^^} " =~ " ${configcmp^^} " ]]; then
+            CONFIG_LIST+=("${config}")
+          fi
+        done
+      done
+    fi
+
+    if [[ ${DEBUG} == "yes" ]]; then
+      debug "Installing the following: "
+      for pkg in ${INSTALL_LIST[@]}; do
+        debug "    ${pkg}"
+      done
+      debug "Copying configs: "
+      for config in ${CONFIG_LIST[@]}; do
+        debug "    ${config}"
+      done
+    fi
+}
+
+main () {
+
+  parse_args "$@" # sets  ARGS[@] to supplied arguments
+
+  # Updating System
+  # dnf update -y
+
+  # # Making .config and Moving dotfiles and Background to .config
+  # mkdir ~/.config
+  # chown $(whoami): ~/.config
+  # mv ./dotconfig/* ~/.config
+  # mv ./bg.jpg ~/.config
+
+  # # Installing Essential Programs 
+  # dnf install sddm bspwm sxhkd kitty rofi polybar picom thunar nitrogen lxpolkit
+  # # Installing Other less important Programs
+  # dnf install mangohud gimp vim lxappearance
+  # # Installing Custom ocs-url package
+  # dnf install ./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm
+
+  # # Installing fonts
+  # dnf install fontawesome-fonts fontawesome-fonts-web
+  # wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip
+  # unzip FiraCode.zip -d /usr/share/fonts
+  # wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip
+  # unzip Meslo.zip -d /usr/share/fonts
+  # # Reloading Font
+  # fc-cache -vf
+  # # Removing zip Files
+  # rm ./FiraCode.zip ./Meslo.zip
+
+  # # Enabling Services and Graphical User Interface
+  # systemctl enable sddm
+  # systemctl set-default graphical.target
+
+
+}
+
+
+if [[ $(basename $0) == "install.sh" ]]; then main "$@"; fi

--- a/install.sh
+++ b/install.sh
@@ -289,7 +289,7 @@ main () {
   # rm ./FiraCode.zip ./Meslo.zip
 
   if [[ ${FONTS} ]]; then
-    debug "installing zip fonts..."
+    debug "installing nerd fonts..."
     if [[ ! -f Meslo.zip ]]; then
       debug "$(wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip 2>&1)"
     fi

--- a/install.sh
+++ b/install.sh
@@ -68,8 +68,8 @@ Options: \n\
   -a    install lxappearance \n\
   -b    install background (in bg.jpg) \n\
   -c    copy configs of selected components into ~/.config \n\
-  -f    install fonts
-  -g    install GIMP
+  -f    install fonts \n\
+  -g    install GIMP \n\
   -k    install kitty terminal emulator \n\
   -l    install lxpolkit \n\
   -m    install mangohud \n\
@@ -84,7 +84,7 @@ Options: \n\
   -u    run system update \n\
   -w    install bspwm window manager \n\
   -x    install sxhkd hotkey manager \n\
-  -X    install Xorg option files
+  -X    install Xorg option files \n\
 \n\
 Examples: $(basename $0) all          (installs all components) \n\
           $(basename $0) essential    (installs all essential components) \n\

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,8 @@
 # known bugs so far:
 # - there may be unexpected behavior if weird args are given?
 # -- need to robust the user input checking a bit.
+# - if only options are given, overides with 'all'
+# -- fixed
 # - polybar is bugged, fonts don't fix it.
 
 readonly VERSION="1.0.0"
@@ -143,7 +145,7 @@ parse_args () {
       finish "${ERR_TOOMANY_OPT}" "too many options"
     fi
 
-    if [[ ! ${ARGS[0]} ]]; then
+    if [[ ! ${ARGS[0]} && ${NUM_OPTS} -eq 0 ]]; then
       ARGS[0]="all"
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -304,10 +304,10 @@ main () {
     if [[ ! -d ~/.fonts ]]; then
       mkdir -p ~/.fonts
     fi
-    debug "$(unzip FiraCode.zip -d ~/.fonts 2>&1)"
-    debug "$(unzip Meslo.zip -d ~/.fonts 2>&1)"
+    debug "$(unzip -n FiraCode.zip -d ~/.fonts 2>&1)"
+    debug "$(unzip -n Meslo.zip -d ~/.fonts 2>&1)"
     #rm -rf *.zip
-    debug "$(fc-cache -f 2>&1)"
+    debug "$(fc-cache -fv 2>&1)"
   fi
 
   # # Enabling Services and Graphical User Interface

--- a/install.sh
+++ b/install.sh
@@ -304,7 +304,8 @@ main () {
     if [[ ! -d ~/.fonts ]]; then
       mkdir -p ~/.fonts
     fi
-    debug "$(unzip FiraCode.zip Meslo.zip -d ~/.fonts 2>&1)"
+    debug "$(unzip FiraCode.zip -d ~/.fonts 2>&1)"
+    debug "$(unzip Meslo.zip -d ~/.fonts 2>&1)"
     #rm -rf *.zip
     debug "$(fc-cache -f 2>&1)"
   fi

--- a/install.sh
+++ b/install.sh
@@ -213,10 +213,12 @@ main () {
 
   parse_args "$@" # sets  ARGS[@] to supplied arguments
 
+  echo "this may take a bit..."
   # Updating System
   # dnf update -y
   if [[ "${UPDATE}" == "y" ]]; then
-    sudo dnf update -y
+    debug "Updating system..."
+    sudo dnf update -y 2>&1>/dev/null
   fi
 
   # # Making .config and Moving dotfiles and Background to .config
@@ -226,21 +228,28 @@ main () {
   # mv ./bg.jpg ~/.config
 
   if [[ ${CONFIGS} ]]; then
+    debug "creating .config..."
     mkdir ~/.config
+    debug "copying configs..."
     for config in ${CONFIG_LIST[@]}; do
+            debug "    ${config}"
       cp -r ./dotconfig/${config} ~/.config
     done
   fi
 
   if [[ ${XCONFIGS} ]]; then
+    debug "copying X configs..."
     for config in ${XCONFIG_LIST[@]}; do
+        debug "    ${config}"
       cp -r ./${config} ~
     done
   fi
 
   if [[ ${BG} ]]; then
+    debug "copying background to .config..."
     cp ./bg.jpg ~/.config
-  
+  fi
+
   # # Installing Essential Programs 
   # dnf install sddm bspwm sxhkd kitty rofi polybar picom thunar nitrogen lxpolkit
   # # Installing Other less important Programs
@@ -249,7 +258,8 @@ main () {
   # dnf install ./rpm-packages/ocs-url-3.1.0-1.fc20.x86_64.rpm
 
   if [[ ${INSTALL_LIST} ]]; then
-    sudo dnf install ${INSTALL_LIST[@]}
+    debug "installing packages..."
+    sudo dnf -y install ${INSTALL_LIST[@]} 2>&1>/dev/null
   fi
 
   # # Installing fonts
@@ -264,18 +274,21 @@ main () {
   # rm ./FiraCode.zip ./Meslo.zip
 
   if [[ ${FONTS} ]]; then
-      wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip
-      wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip
-      sudo unzip *.zip -d /usr/share/fonts
-      rm -rf *.zip
-      sudo fc-cache -f
+    debug "installing zip fonts..."
+    wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip 2>&1>/dev/null
+    wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip 2>&1>/dev/null
+    sudo unzip *.zip -d /usr/share/fonts 2>&1>/dev/null
+    rm -rf *.zip
+    sudo fc-cache -f
   fi
 
   # # Enabling Services and Graphical User Interface
 
   if [[ ${SERVICES} ]]; then
-    systemctl enable sddm
-    systemctl set-default graphical.target
+    debug "enabling sddm..."
+    sddm=$(systemctl enable sddm)
+    debug "setting graphical target..."
+    graphical=$(systemctl set-default graphical.target)
   fi
 
 }

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,11 @@
 
 # known bugs so far:
 # - there may be unexpected behavior if weird args are given?
-# -- need to robust the user input checking a bit.
+# -- need to robust the user input checking a bit. (fixed?)
 # - if only options are given, overides with 'all'
 # -- fixed
-# - polybar is bugged, fonts don't fix it.
+# - polybar is bugged, fonts don't fix it?
+# -- fixed? unzipped fonts a la video, seems to have worked.
 
 readonly VERSION="1.0.0"
 readonly ERR_UNK_OPT=64
@@ -292,15 +293,20 @@ main () {
   # rm ./FiraCode.zip ./Meslo.zip
 
   if [[ ${FONTS} ]]; then
-    debug "installing nerd fonts..."
+    debug "downloading nerd fonts..."
     if [[ ! -f Meslo.zip ]]; then
       debug "$(wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip 2>&1)"
     fi
     if [[ ! -f FiraCode.zip ]]; then
       debug "$(wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraCode.zip 2>&1)"
     fi
+    debug "unzipping nerd fonts..."
+    if [[ ! -d ~/.fonts ]]; then
+      mkdir -p ~/.fonts
+    fi
+    debug "$(unzip FiraCode.zip Meslo.zip -d ~/.fonts 2>&1)"
     #rm -rf *.zip
-    sudo fc-cache -f
+    debug "$(fc-cache -f 2>&1)"
   fi
 
   # # Enabling Services and Graphical User Interface

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# known bugs so far:
+# - there may be unexpected behavior if weird args are given?
+# -- need to robust the user input checking a bit.
+
 readonly VERSION="1.0.0"
 readonly ERR_UNK_OPT=64
 readonly ERR_TOOMANY_OPT=65

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 # known bugs so far:
 # - there may be unexpected behavior if weird args are given?
 # -- need to robust the user input checking a bit.
+# - polybar is bugged, fonts don't fix it.
 
 readonly VERSION="1.0.0"
 readonly ERR_UNK_OPT=64


### PR DESCRIPTION
Hi again! Once again, loved the video, while watching once more realized some stuff that I missed on my first pull request.

So, here it is again. All "issues" I have fore/seen are listed toward the top of install.sh and the rest ...is in the code.

Restructured to allow use of switches to more granularly-control the install and config copy process. Also added meta-options all, essential, and optional to allow "group" installs, which override the switches if you try to use both. By default, running just ./install.sh will select 'all'.

Highly recommend testing/running with -v (lowercase 'v') to turn on debug messages.